### PR TITLE
Fix reversed shunting yard

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,8 +59,8 @@ fn repl() {
 
 fn test() {
     let test = r#"
-a + b + c
-    "#;
+a * b + c * d * (a + b) / 2
+"#;
 
     let mut blocks = BlockTree::new(test, 0);
     let indents    = blocks.indents();

--- a/src/moli/syntax/lexer/lexer.rs
+++ b/src/moli/syntax/lexer/lexer.rs
@@ -91,8 +91,8 @@ pub fn lexer(data: &mut Chars) -> Lexer {
     lexer.matchers_mut().push(Box::new(matcher_boolean));
     lexer.matchers_mut().push(Box::new(matcher_types));    
     lexer.matchers_mut().push(Box::new(matcher_keyword));
+    lexer.matchers_mut().push(Box::new(matcher_operator));    
     lexer.matchers_mut().push(Box::new(matcher_identifier));
-    lexer.matchers_mut().push(Box::new(matcher_operator));
     lexer.matchers_mut().push(Box::new(matcher_symbol));
     lexer
 }

--- a/src/moli/syntax/parser/ast.rs
+++ b/src/moli/syntax/parser/ast.rs
@@ -44,6 +44,8 @@ pub enum Operand {
     Gt,
     LtEquals,
     GtEquals,
+    And,
+    Or,
 }
 
 pub fn operand(v: &str) -> Option<(Operand, u8)> {
@@ -60,6 +62,8 @@ pub fn operand(v: &str) -> Option<(Operand, u8)> {
         ">"  => Some((Operand::Gt, 4)),
         "<=" => Some((Operand::LtEquals, 4)),
         ">=" => Some((Operand::GtEquals, 4)),
+        "and" => Some((Operand::And, 4)),
+        "or" => Some((Operand::Or, 4)),
         _ => None,
     }
 }


### PR DESCRIPTION
left = right

```
>> a and b or c
Expression(
    Operation {
        left: Operation {
            left: Identifier(
                "a"
            ),
            op: And,
            right: Identifier(
                "b"
            )
        },
        op: Or,
        right: Identifier(
            "c"
        )
    }
)
>> a * b + c * d * (a + b) / 2
Expression(
    Operation {
        left: Operation {
            left: Identifier(
                "a"
            ),
            op: Mul,
            right: Identifier(
                "b"
            )
        },
        op: Plus,
        right: Operation {
            left: Operation {
                left: Operation {
                    left: Identifier(
                        "c"
                    ),
                    op: Mul,
                    right: Identifier(
                        "d"
                    )
                },
                op: Mul,
                right: Operation {
                    left: Identifier(
                        "a"
                    ),
                    op: Plus,
                    right: Identifier(
                        "b"
                    )
                }
            },
            op: Div,
            right: IntLiteral(
                2
            )
        }
    }
)
>> 
```